### PR TITLE
[TDH-29] 약관동의 및 닉네입력 페이지 추가

### DIFF
--- a/DiningCoach.xcodeproj/project.pbxproj
+++ b/DiningCoach.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		65F8854F2A32764900D151F1 /* View+LineHeightFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F8854E2A32764900D151F1 /* View+LineHeightFont.swift */; };
 		65F885532A327AF700D151F1 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F885522A327AF700D151F1 /* SplashView.swift */; };
 		65F885592A341B6000D151F1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 65F885582A341B6000D151F1 /* LaunchScreen.storyboard */; };
+		8FF418B52A4EC8550090FA34 /* TermsAgreementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF418B42A4EC8550090FA34 /* TermsAgreementView.swift */; };
+		8FF418B72A4EC8720090FA34 /* NicknameInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF418B62A4EC8720090FA34 /* NicknameInputView.swift */; };
+		8FF418B92A4EC87B0090FA34 /* SigninCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF418B82A4EC87B0090FA34 /* SigninCompleteView.swift */; };
 		A51E1C372A405DDF00E4EBA3 /* LoginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51E1C362A405DDF00E4EBA3 /* LoginStore.swift */; };
 		A51E1C3A2A40606800E4EBA3 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = A51E1C392A40606800E4EBA3 /* KakaoSDK */; };
 		A51E1C3D2A4061C800E4EBA3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51E1C3C2A4061C800E4EBA3 /* AppDelegate.swift */; };
@@ -64,6 +67,9 @@
 		65F8854E2A32764900D151F1 /* View+LineHeightFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+LineHeightFont.swift"; sourceTree = "<group>"; };
 		65F885522A327AF700D151F1 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		65F885582A341B6000D151F1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8FF418B42A4EC8550090FA34 /* TermsAgreementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAgreementView.swift; sourceTree = "<group>"; };
+		8FF418B62A4EC8720090FA34 /* NicknameInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameInputView.swift; sourceTree = "<group>"; };
+		8FF418B82A4EC87B0090FA34 /* SigninCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninCompleteView.swift; sourceTree = "<group>"; };
 		A51E1C362A405DDF00E4EBA3 /* LoginStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStore.swift; sourceTree = "<group>"; };
 		A51E1C3C2A4061C800E4EBA3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A51E1C402A4066D100E4EBA3 /* DiningCoach.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DiningCoach.entitlements; sourceTree = "<group>"; };
@@ -173,6 +179,9 @@
 				65F885502A327AE200D151F1 /* Scene */,
 				655D9B8F2A39D9FF005E133E /* Component */,
 				65F8854D2A32761E00D151F1 /* Helper */,
+				8FF418B42A4EC8550090FA34 /* TermsAgreementView.swift */,
+				8FF418B62A4EC8720090FA34 /* NicknameInputView.swift */,
+				8FF418B82A4EC87B0090FA34 /* SigninCompleteView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -372,13 +381,16 @@
 				A51E1C3D2A4061C800E4EBA3 /* AppDelegate.swift in Sources */,
 				65F8854C2A3275B000D151F1 /* Color+Primary.swift in Sources */,
 				65F885302A2EAB3900D151F1 /* Font+Pretendard.swift in Sources */,
+				8FF418B72A4EC8720090FA34 /* NicknameInputView.swift in Sources */,
 				655D9B962A39DBED005E133E /* DCButton+Style.swift in Sources */,
 				A51E1C372A405DDF00E4EBA3 /* LoginStore.swift in Sources */,
+				8FF418B52A4EC8550090FA34 /* TermsAgreementView.swift in Sources */,
 				A526DDC52A092B0300B682BF /* ContentView.swift in Sources */,
 				A51E1C432A406A4800E4EBA3 /* RegistrationStore.swift in Sources */,
 				65F8854F2A32764900D151F1 /* View+LineHeightFont.swift in Sources */,
 				655D9B922A39DA0C005E133E /* DCButton.swift in Sources */,
 				655D9B8E2A39D815005E133E /* Color+Neutral.swift in Sources */,
+				8FF418B92A4EC87B0090FA34 /* SigninCompleteView.swift in Sources */,
 				A526DDC32A092B0300B682BF /* DiningCoachApp.swift in Sources */,
 				65F885532A327AF700D151F1 /* SplashView.swift in Sources */,
 				A51E1C462A406BAC00E4EBA3 /* Validation.swift in Sources */,

--- a/DiningCoach.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DiningCoach.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "bc268c28fb170f494de9e9927c371b8342979ece",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "d788f9a5a888f16253b9c3d9f3bd794835708c3f",
+        "version" : "2.15.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/DiningCoach/Sources/NicknameInputView.swift
+++ b/DiningCoach/Sources/NicknameInputView.swift
@@ -5,4 +5,145 @@
 //  Created by 심현석 on 2023/06/30.
 //
 
-import Foundation
+import SwiftUI
+
+struct NicknameInputView: View {
+    @EnvironmentObject var navigation: SigninNavigation
+    @State private var isPresented: Bool = false
+    @State private var isCompleted: Bool = false
+    
+    @State var nickname: String = ""
+    
+    @State var isCombinationValid: Bool = false
+    @State var isLengthValid: Bool = false
+    
+    var body: some View {
+        VStack {
+            VStack {
+                Spacer()
+                HStack {
+                    Text("가입이 거의 끝나가요!\n어떻게 불러드리면 될까요?")
+                        .font(.pretendard(weight: .bold, size: 22))
+                        .lineSpacing(6)
+                    Spacer()
+                }
+            }
+            .frame(height: 80)
+            
+            Spacer()
+                .frame(height: 120)
+            
+            VStack(alignment: .leading, spacing: 0) {
+                TextField("닉네임을 입력해 주세요", text: $nickname)
+                    .font(.pretendard(weight: .semiBold, size: 16))
+                    .tint(Color.primary500)
+                    .frame(height: 48)
+                
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundColor(nickname.isEmpty ? Color.neutral300 : Color.primary500)
+                
+                Spacer()
+                    .frame(height: 8)
+                
+                HStack(spacing: 16) {
+                    HStack(spacing: 0) {
+                        Text("한글, 영문, 숫자 조합")
+                        
+                        Image(systemName: "checkmark")
+                            .frame(width: 16, height: 16)
+                    }
+                    .foregroundColor(isCombinationValid ? .primary500 : .neutral300)
+                    
+                    HStack(spacing: 0) {
+                        Text("16자 이내")
+                        
+                        Image(systemName: "checkmark")
+                            .frame(width: 16, height: 16)
+                    }
+                    .foregroundColor(isLengthValid ? .primary500 : .neutral300)
+
+                    HStack(spacing: 0) {
+                        Text("단, 한글은 2글자로 인식")
+                            .foregroundColor(.primary500)
+                    }
+                }
+                .font(.pretendard(weight: .semiBold, size: 11))
+            }
+            
+            Spacer()
+            
+            DCButton("완료", style: .primary) {
+                // 다음페이지
+                isPresented = true
+            }
+            .padding(.vertical, 16)
+            .disabled(!isCompleted)
+        }
+        .padding(.horizontal, 16)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button {
+                    navigation.showSheet = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.black)
+                }
+            }
+        }
+        .onChange(of: nickname) { newValue in
+            isCombinationValid = combinationValid(nickname: nickname)
+            isLengthValid = lengthValid(nickname: nickname)
+            
+            isCompleted = isLengthValid && isCombinationValid
+        }
+        .navigationDestination(isPresented: $isPresented) {
+            SigninCompleteView(nickname: nickname)
+        }
+    }
+    
+    func combinationValid(nickname: String) -> Bool {
+        let kor = nickname.range(of: "[가-힣]+", options: .regularExpression) != nil
+        let eng = nickname.range(of: "[a-zA-Z]+", options: .regularExpression) != nil
+        let num = nickname.range(of: "[0-9]+", options: .regularExpression) != nil
+        
+        let trueCount = [kor, eng, num].filter { $0 }.count
+        let isCombinationValid = trueCount == 2 || trueCount == 3
+        
+        return isCombinationValid
+    }
+    
+    func lengthValid(nickname: String) -> Bool {
+        let filter = nickname.range(of: "[가-힣a-zA-Z0-9]+", options: .regularExpression) != nil
+        let korCount = extractKorCount(text: nickname)
+        let engnumCount = extractEngNumCount(from: nickname)
+        
+        if filter && (korCount + engnumCount >= 2 && korCount + engnumCount <= 16) {
+            return true
+        }
+        return false
+    }
+    
+    func extractKorCount(text: String) -> Int {
+        let regex = try? NSRegularExpression(pattern: "[가-힣]+", options: [])
+        if let match = regex?.firstMatch(in: text, options: [], range: NSRange(text.startIndex..., in: text)) {
+            return match.range.length * 2
+        }
+        return 0
+    }
+    
+    func extractEngNumCount(from text: String) -> Int {
+        let regex = try? NSRegularExpression(pattern: "[a-zA-Z0-9]+", options: [])
+        if let match = regex?.firstMatch(in: text, options: [], range: NSRange(text.startIndex..., in: text)) {
+            return match.range.length
+        }
+        return 0
+    }
+}
+
+struct NicknameInputView_Previews: PreviewProvider {
+    static var previews: some View {
+        NicknameInputView()
+    }
+}

--- a/DiningCoach/Sources/NicknameInputView.swift
+++ b/DiningCoach/Sources/NicknameInputView.swift
@@ -1,0 +1,8 @@
+//
+//  NicknameInputView.swift
+//  DiningCoach
+//
+//  Created by 심현석 on 2023/06/30.
+//
+
+import Foundation

--- a/DiningCoach/Sources/SigninCompleteView.swift
+++ b/DiningCoach/Sources/SigninCompleteView.swift
@@ -1,0 +1,8 @@
+//
+//  SigninCompleteView.swift
+//  DiningCoach
+//
+//  Created by 심현석 on 2023/06/30.
+//
+
+import Foundation

--- a/DiningCoach/Sources/SigninCompleteView.swift
+++ b/DiningCoach/Sources/SigninCompleteView.swift
@@ -5,4 +5,74 @@
 //  Created by 심현석 on 2023/06/30.
 //
 
-import Foundation
+import SwiftUI
+
+struct SigninCompleteView: View {
+    @EnvironmentObject var navigation: SigninNavigation
+    
+    var nickname: String
+    
+    var body: some View {
+        VStack {
+            VStack {
+                Spacer()
+                HStack {
+                    Text("\(nickname)님,\n가입이 완료되었어요!")
+                        .font(.pretendard(weight: .bold, size: 22))
+                        .lineSpacing(6)
+                    Spacer()
+                }
+            }
+            .frame(height: 80)
+            
+            Spacer()
+                .frame(height: 40)
+            
+            VStack {
+                HStack {
+                    VStack(alignment:. leading, spacing: 16) {
+                        Text("다이닝코치는 식단관리 서비스로써\n식단일기 기록, 식단 추천 등 여러 기능들을\n제공하고 있어요.")
+                        
+                        Text("맞춤형 정보를 제공하기 위해서는\n\(nickname)님에 대한 추가정보가 필요해요!\n추가정보는 7단계로 구성되어 있으며, 식단 구성에\n필요한 간단한 정보에 대해 여쭤보려고 해요.")
+                        
+                        Text("입력하신 정보는 다른 목적으로 사용되거나 제3자에게 제공되지 않습니다.")
+                    }
+                    .font(.pretendard(weight: .medium, size: 16))
+                    .lineSpacing(8)
+                    Spacer()
+                }
+            }
+            
+            Spacer()
+            
+            VStack(spacing: 8) {
+                DCButton("추가정보 입력하기", style: .primary) {
+                    // 다음페이지
+                }
+                
+                DCButton("건너뛰기", style: .secondary) {
+                    navigation.showSheet = false
+                }
+            }
+            .padding(.vertical, 16)
+        }
+        .padding(.horizontal, 16)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button {
+                    navigation.showSheet = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.black)
+                }
+            }
+        }
+    }
+}
+
+struct SigninCompleteView_Previews: PreviewProvider {
+    static var previews: some View {
+        SigninCompleteView(nickname: "민수민수")
+    }
+}

--- a/DiningCoach/Sources/TermsAgreementView.swift
+++ b/DiningCoach/Sources/TermsAgreementView.swift
@@ -1,0 +1,196 @@
+//
+//  TermsAgreementView.swift
+//  DiningCoach
+//
+//  Created by 심현석 on 2023/06/30.
+//
+
+import SwiftUI
+
+class SigninNavigation: ObservableObject {
+    @Published var showSheet = false
+}
+
+struct TempHomeView: View {
+    @StateObject private var navigation = SigninNavigation()
+    
+    var body: some View {
+        NavigationStack {
+            Button {
+                navigation.showSheet = true
+            } label: {
+                Text("Go sheet")
+            }
+            .sheet(isPresented: $navigation.showSheet) {
+                TermsAgreementView()
+            }
+            .environmentObject(navigation)
+        }
+    }
+}
+
+struct TermsAgreementView: View {
+    @EnvironmentObject var navigation: SigninNavigation
+    @State private var isPresented: Bool = false
+    @State private var isCompleted: Bool = false
+    
+    @State private var isSelectedAll: Bool = false
+    @State private var selectedStates: [Bool] = [false, false, false, false, false]
+    
+    var types: Array<TermsType> = [.mandatory, .mandatory, .mandatory, .mandatory, .optional]
+    var titles = ["서비스 이용약관", "개인정보 수집 및 이용 동의", "민감정보 수집 및 이용 동의", "만 14세 이상이에요", "마케팅 정보 수신 동의"]
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                VStack {
+                    Spacer()
+                    HStack {
+                        Text("서비스 이용을 위해\n약관을 확인해 주세요")
+                            .font(.pretendard(weight: .bold, size: 22))
+                            .lineSpacing(6)
+                        Spacer()
+                    }
+                }
+                .frame(height: 80)
+                
+                Spacer()
+                    .frame(height: 48)
+                
+                VStack(alignment: .leading) {
+                    Button {
+                        isSelectedAll.toggle()
+                        selectedStates = Array(repeating: isSelectedAll, count: selectedStates.count)
+                    } label: {
+                        HStack(spacing: 0) {
+                            if isSelectedAll {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                                    .foregroundColor(.primary500)
+                            } else {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                                    .foregroundColor(.neutral200)
+                            }
+                            
+                            Text("약관 전체 동의")
+                                .font(.medium, size: 18, lineHeight: 24)
+                                .padding(8)
+                                .foregroundColor(.black)
+                        }
+                    }
+                    
+                    Spacer()
+                        .frame(height: 25)
+                    
+                    ForEach(0 ..< selectedStates.count) { index in
+                        DetailTermsView(type: types[index], title: titles[index], isSelected: $selectedStates[index], isSelectedAll: $isSelectedAll, selectedStates: $selectedStates)
+                            .onChange(of: selectedStates) { _ in
+                                isCompleted = selectedStates.prefix(4).allSatisfy { $0 }
+                            }
+                    }
+                }
+                
+                Spacer()
+                
+                DCButton("다음", style: .primary) {
+                    // 다음페이지
+                    isPresented = true
+                }
+                .padding(.vertical, 16)
+                .disabled(!isCompleted)
+            }
+            .padding(.horizontal, 16)
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button {
+                        navigation.showSheet = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .foregroundColor(.black)
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $isPresented) {
+                NicknameInputView()
+            }
+        }
+    }
+}
+
+enum TermsType {
+    case mandatory
+    case optional
+}
+
+struct DetailTermsView: View {
+    var type: TermsType
+    var title: String
+    
+    @Binding var isSelected: Bool
+    @Binding var isSelectedAll: Bool
+    @Binding var selectedStates: [Bool]
+    
+    var body: some View {
+        HStack {
+            Button {
+                isSelected.toggle()
+                
+                if !isSelected {
+                    isSelectedAll = false
+                } else if !(selectedStates.contains { !$0 }) {
+                    isSelectedAll = true
+                }
+            } label: {
+                HStack {
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.primary500)
+                    } else {
+                        Image(systemName: "checkmark")
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.neutral200)
+                    }
+                    
+                    Spacer()
+                        .frame(width: 8)
+                    
+                    if type == .mandatory {
+                        Text("[필수]")
+                            .font(.medium, size: 16, lineHeight: 24)
+                    } else {
+                        Text("(선택)")
+                            .font(.medium, size: 16, lineHeight: 24)
+                    }
+                    
+                    Spacer()
+                        .frame(width: 3)
+                    
+                    Text(title)
+                        .font(.medium, size: 16, lineHeight: 24)
+                }
+                .padding(.vertical, 8)
+                .foregroundColor(.black)
+            }
+            
+            Spacer()
+            
+            NavigationLink {
+                // 약관 보기
+            } label: {
+                Text("보기")
+                    .font(.bold, size: 11, lineHeight: 16)
+                    .foregroundColor(.neutral300)
+            }
+        }
+    }
+}
+
+struct TermsAgreementView_Previews: PreviewProvider {
+    static var previews: some View {
+        TempHomeView()
+    }
+}


### PR DESCRIPTION
# 요약
- 약관동의를 받는 뷰 추가
    - 약관 내용이 나오면 약관 상세보기 페이지를 추가가 필요합니다.
- 닉네임을 입력하는 뷰 추가
    - 정규식을 이용해 닉네임 조건 설정하였습니다.
    - API 명세서가 나오면 닉네임 존재 여부를 확인하는 코드가 필요합니다.
- 가입완료 뷰 추가

# 동작 확인
![TDH -29](https://github.com/DiningCoach-Team/DiningCoach-iOS/assets/114726674/bd65c027-7cc0-4a41-a778-6506206f88bd)
